### PR TITLE
fix usage of atom-package-deps.install() API

### DIFF
--- a/lib/tool-bar-markdown-writer.coffee
+++ b/lib/tool-bar-markdown-writer.coffee
@@ -182,7 +182,7 @@ module.exports =
 
   activate: ->
     require('atom-package-deps')
-      .install('tool-bar', 'markdown-writer')
+      .install('tool-bar-markdown-writer', true)
       .then(=> @activateBar())
 
   activateBar: ->


### PR DESCRIPTION
every activation of the toolbar emits this warning message

```
Package-Deps] Unable to get loaded package 'tool-bar'
(anonymous) @ (...)/node_modules/atom-package-deps/lib/helpers.js:41
```

the reason is a wrong [API usage][8a28b864] of atom-package-deps.install().
the first parameter should be the name of the package which installs the
dependencies. the second argument is a boolean to prompt for confirmation
before install requested packages.

with this PR: atom ensures that all required packages are usable before 
the tool-bar-md-writer is activated. missing packages are offered for 
installation. before any installation the user is prompted for 
confirmation. [screenshots][qoonr45a]

  [8a28b864]: https://github.com/steelbrain/package-deps#how-it-works
  [qoonr45a]: https://github.com/steelbrain/package-deps#screenshots